### PR TITLE
Experiment with nailgun integration.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import scalatex.ScalatexReadme
+
 import sbtassembly.AssemblyPlugin.defaultShellScript
 
 
@@ -113,6 +114,7 @@ lazy val terminal = project
  */
 lazy val amm = project
   .dependsOn(terminal, ops)
+  .settings(packSettings)
   .settings(
     macroSettings,
     sharedSettings,
@@ -121,6 +123,7 @@ lazy val amm = project
     name := "ammonite",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+      "com.martiansoftware" % "nailgun-server" % "0.9.1",
       "jline" % "jline" % "2.12",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "org.apache.ivy" % "ivy" % "2.4.0",
@@ -135,6 +138,10 @@ lazy val amm = project
       else Seq("com.chuusai" %% "shapeless" % "2.1.0" % "test")
     ),
     javaOptions += "-Xmx4G",
+    packMain := Map(
+      "amm" -> "ammonite.Main",
+      "amm_ng" -> "com.martiansoftware.nailgun.NGServer"
+    ),
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
       prependShellScript = Some(
         // G1 Garbage Collector is awesome https://github.com/lihaoyi/Ammonite/issues/216

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,5 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.8.0")
+
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.5")


### PR DESCRIPTION
To run:
- install nailgun (for example on OSX, brew install nailgun)
- run `sbt amm/pack`
- start server `./amm/target/pack/bin/amm_ng`
- run `ng ammonite.Main <args>` instead of typical `amm <args>`

The repl doesn't work, pressing up/down/ctrl-c is broken for some
reason.

Scala scripts work like a charm. Rough numbers from compiling a new file on a warm sever:
- single file: ~0.3s
- import $file: ~0.5s
- import $ivy: ~1.0s
